### PR TITLE
[ISSUE-010] Kotlin, Compose 버전 최신화

### DIFF
--- a/gradle/dependencies.toml
+++ b/gradle/dependencies.toml
@@ -6,7 +6,7 @@ android-gradle = "7.1.2"
 androidx-core = "1.7.0"
 androidx-lifecycle = "2.3.1"
 androidx-activity = "1.4.0"
-compose = "1.0.1"
+compose = "1.2.0-alpha08"
 dagger = "2.41"
 
 junit = "4.13.2"

--- a/gradle/dependencies.toml
+++ b/gradle/dependencies.toml
@@ -7,6 +7,7 @@ androidx-core = "1.7.0"
 androidx-lifecycle = "2.3.1"
 androidx-activity = "1.4.0"
 compose = "1.2.0-alpha08"
+material3 = "1.0.0-alpha10"
 dagger = "2.41"
 
 junit = "4.13.2"
@@ -26,6 +27,7 @@ androidx-compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "c
 androidx-compose-ui-tooling-core = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 
 junit4 = { module = "junit:junit", version.ref = "junit" }
 

--- a/gradle/dependencies.toml
+++ b/gradle/dependencies.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.5.21"
+kotlin = "1.6.20"
 coroutines = "1.6.1"
 
 android-gradle = "7.1.2"

--- a/modules/presentation/build.gradle.kts
+++ b/modules/presentation/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 
     implementation(libs.androidx.compose.ui.core)
     implementation(libs.androidx.compose.material)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui.tooling.preview)
 
     implementation(libs.androidx.lifecycle.runtime)


### PR DESCRIPTION
### 의존성 변경사항
- kotlin : `1.5.21` -> `1.6.20` (업데이트)
- compose: `1.0.1` -> `1.2.0-alpha08` (업데이트)
- compose-material3 : `1.0.0-alpha10` (추가)