### PR TITLE
유저 정보 관련 기능 추가

### DIFF
--- a/modules/data/build.gradle.kts
+++ b/modules/data/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(Modules.DOMAIN))
+    implementation(libs.coroutines.core)
 
     implementation(libs.hilt.core)
     kapt(libs.hilt.compiler)

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/model/ProfileEntity.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/model/ProfileEntity.kt
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.data.model
+
+import kr.co.knowledgerally.domain.model.Profile
+
+data class ProfileEntity(
+    val username: String,
+    val imageUrl: String?,
+    val introduction: String,
+    val portfolio: String,
+)
+
+fun ProfileEntity.toDomain() = Profile(
+    username = username,
+    imageUrl = imageUrl,
+    introduction = introduction,
+    portfolio = portfolio
+)

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/model/UserEntity.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/model/UserEntity.kt
@@ -7,6 +7,7 @@ data class UserEntity(
     val profile: ProfileEntity,
     val ballCount: Int,
     val pushActive: Boolean,
+    val coach: Boolean,
 )
 
 fun UserEntity.toDomain() = User(
@@ -14,4 +15,5 @@ fun UserEntity.toDomain() = User(
     profile = profile.toDomain(),
     ballCount = ballCount,
     pushActive = pushActive,
+    coach = coach,
 )

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/model/UserEntity.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/model/UserEntity.kt
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.data.model
+
+import kr.co.knowledgerally.domain.model.User
+
+data class UserEntity(
+    val id: String,
+    val profile: ProfileEntity,
+    val ballCount: Int,
+    val pushActive: Boolean,
+)
+
+fun UserEntity.toDomain() = User(
+    id = id,
+    profile = profile.toDomain(),
+    ballCount = ballCount,
+    pushActive = pushActive,
+)

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
@@ -27,4 +27,7 @@ internal class UserRepositoryImpl @Inject constructor(
         .getUser()
         .map { it.toDomain() }
         .onSuccess { user.value = it }
+
+    override suspend fun updatePushActive(active: Boolean): Result<Unit> =
+        userRemoteDataSource.updatePushActive(active)
 }

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
@@ -1,5 +1,8 @@
 package kr.co.knowledgerally.data.repo
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kr.co.knowledgerally.data.model.toData
 import kr.co.knowledgerally.data.model.toDomain
 import kr.co.knowledgerally.data.source.UserRemoteDataSource
@@ -11,13 +14,17 @@ import javax.inject.Inject
 internal class UserRepositoryImpl @Inject constructor(
     private val userRemoteDataSource: UserRemoteDataSource
 ) : UserRepository {
+    private var user = MutableStateFlow<User?>(null)
 
     override suspend fun isOnboarded(): Result<Boolean> = userRemoteDataSource.isOnboarded()
 
     override suspend fun submitOnboard(onboard: Onboard): Result<Unit> =
         userRemoteDataSource.submitOnboard(onboard.toData())
 
-    override suspend fun getUser(): Result<User> = userRemoteDataSource
+    override fun getUserStream(): Flow<User> = user.filterNotNull()
+
+    override suspend fun refreshUser(): Result<User> = userRemoteDataSource
         .getUser()
         .map { it.toDomain() }
+        .onSuccess { user.value = it }
 }

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/repo/UserRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package kr.co.knowledgerally.data.repo
 
 import kr.co.knowledgerally.data.model.toData
+import kr.co.knowledgerally.data.model.toDomain
 import kr.co.knowledgerally.data.source.UserRemoteDataSource
 import kr.co.knowledgerally.domain.model.Onboard
+import kr.co.knowledgerally.domain.model.User
 import kr.co.knowledgerally.domain.repo.UserRepository
 import javax.inject.Inject
 
@@ -14,4 +16,8 @@ internal class UserRepositoryImpl @Inject constructor(
 
     override suspend fun submitOnboard(onboard: Onboard): Result<Unit> =
         userRemoteDataSource.submitOnboard(onboard.toData())
+
+    override suspend fun getUser(): Result<User> = userRemoteDataSource
+        .getUser()
+        .map { it.toDomain() }
 }

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/source/UserRemoteDataSource.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/source/UserRemoteDataSource.kt
@@ -1,10 +1,13 @@
 package kr.co.knowledgerally.data.source
 
 import kr.co.knowledgerally.data.model.OnboardEntity
+import kr.co.knowledgerally.data.model.UserEntity
 
 interface UserRemoteDataSource {
 
     suspend fun isOnboarded(): Result<Boolean>
 
     suspend fun submitOnboard(request: OnboardEntity): Result<Unit>
+
+    suspend fun getUser(): Result<UserEntity>
 }

--- a/modules/data/src/main/java/kr/co/knowledgerally/data/source/UserRemoteDataSource.kt
+++ b/modules/data/src/main/java/kr/co/knowledgerally/data/source/UserRemoteDataSource.kt
@@ -10,4 +10,6 @@ interface UserRemoteDataSource {
     suspend fun submitOnboard(request: OnboardEntity): Result<Unit>
 
     suspend fun getUser(): Result<UserEntity>
+
+    suspend fun updatePushActive(active: Boolean): Result<Unit>
 }

--- a/modules/domain/build.gradle.kts
+++ b/modules/domain/build.gradle.kts
@@ -10,6 +10,7 @@ tasks {
 
 dependencies {
     implementation(libs.javax.inject)
+    implementation(libs.coroutines.core)
 
     testImplementation(libs.bundles.junit5)
     testImplementation(libs.truth)

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/Profile.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/Profile.kt
@@ -1,20 +1,8 @@
 package kr.co.knowledgerally.domain.model
 
 data class Profile(
-    val nickname: String,
+    val username: String,
     val imageUrl: String?,
-    val selfIntroduction: String,
-    val webUrls: List<String>,
-) {
-
-    val isEmpty: Boolean get() = this == EMPTY
-
-    companion object {
-        val EMPTY = Profile(
-            nickname = "",
-            imageUrl = null,
-            selfIntroduction = "",
-            webUrls = emptyList()
-        )
-    }
-}
+    val introduction: String,
+    val portfolio: String,
+)

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/User.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/User.kt
@@ -3,4 +3,6 @@ package kr.co.knowledgerally.domain.model
 data class User(
     val id: String,
     val profile: Profile,
+    val ballCount: Int,
+    val pushActive: Boolean,
 )

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/User.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/model/User.kt
@@ -5,4 +5,5 @@ data class User(
     val profile: Profile,
     val ballCount: Int,
     val pushActive: Boolean,
+    val coach: Boolean,
 )

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
@@ -1,5 +1,6 @@
 package kr.co.knowledgerally.domain.repo
 
+import kotlinx.coroutines.flow.Flow
 import kr.co.knowledgerally.domain.model.Onboard
 import kr.co.knowledgerally.domain.model.User
 
@@ -9,5 +10,7 @@ interface UserRepository {
 
     suspend fun submitOnboard(request: Onboard): Result<Unit>
 
-    suspend fun getUser(): Result<User>
+    fun getUserStream(): Flow<User>
+
+    suspend fun refreshUser(): Result<User>
 }

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
@@ -13,4 +13,6 @@ interface UserRepository {
     fun getUserStream(): Flow<User>
 
     suspend fun refreshUser(): Result<User>
+
+    suspend fun updatePushActive(active: Boolean): Result<Unit>
 }

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/repo/UserRepository.kt
@@ -1,10 +1,13 @@
 package kr.co.knowledgerally.domain.repo
 
 import kr.co.knowledgerally.domain.model.Onboard
+import kr.co.knowledgerally.domain.model.User
 
 interface UserRepository {
 
     suspend fun isOnboarded(): Result<Boolean>
 
     suspend fun submitOnboard(request: Onboard): Result<Unit>
+
+    suspend fun getUser(): Result<User>
 }

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/GetUserStreamUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/GetUserStreamUseCase.kt
@@ -1,12 +1,13 @@
 package kr.co.knowledgerally.domain.usecase
 
+import kotlinx.coroutines.flow.Flow
 import kr.co.knowledgerally.domain.model.User
 import kr.co.knowledgerally.domain.repo.UserRepository
 import javax.inject.Inject
 
-class GetUserUseCase @Inject constructor(
+class GetUserStreamUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
 
-    suspend operator fun invoke(): Result<User> = userRepository.getUser()
+    operator fun invoke(): Flow<User> = userRepository.getUserStream()
 }

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/GetUserUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/GetUserUseCase.kt
@@ -1,0 +1,12 @@
+package kr.co.knowledgerally.domain.usecase
+
+import kr.co.knowledgerally.domain.model.User
+import kr.co.knowledgerally.domain.repo.UserRepository
+import javax.inject.Inject
+
+class GetUserUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke(): Result<User> = userRepository.getUser()
+}

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/RefreshUserUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/RefreshUserUseCase.kt
@@ -1,0 +1,11 @@
+package kr.co.knowledgerally.domain.usecase
+
+import kr.co.knowledgerally.domain.repo.UserRepository
+import javax.inject.Inject
+
+class RefreshUserUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke() = userRepository.refreshUser()
+}

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/SignUpUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/SignUpUseCase.kt
@@ -1,14 +1,19 @@
 package kr.co.knowledgerally.domain.usecase
 
-import kr.co.knowledgerally.domain.model.JwtToken
 import kr.co.knowledgerally.domain.model.ProviderToken
 import kr.co.knowledgerally.domain.repo.AuthRepository
+import kr.co.knowledgerally.domain.repo.UserRepository
 import javax.inject.Inject
 
 class SignUpUseCase @Inject constructor(
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
 ) {
 
-    suspend operator fun invoke(providerToken: ProviderToken): Result<JwtToken> =
-        authRepository.signUp(providerToken)
+    suspend operator fun invoke(
+        providerToken: ProviderToken,
+        pushActive: Boolean
+    ): Result<Unit> = authRepository
+        .signUp(providerToken)
+        .mapCatching { userRepository.updatePushActive(pushActive).getOrThrow() }
 }

--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/UpdatePushActiveUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/UpdatePushActiveUseCase.kt
@@ -1,0 +1,11 @@
+package kr.co.knowledgerally.domain.usecase
+
+import kr.co.knowledgerally.domain.repo.UserRepository
+import javax.inject.Inject
+
+class UpdatePushActiveUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke(active: Boolean) = userRepository.updatePushActive(active)
+}

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/main/MainScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/main/MainScreen.kt
@@ -61,6 +61,7 @@ fun MainScreen(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val showWelcome by viewModel.showWelcome.collectAsState()
+    val user by viewModel.user.collectAsState()
 
     Scaffold(
         topBar = {
@@ -70,7 +71,7 @@ fun MainScreen(
                     val visible = currentDestination?.route == MainDestination.Home.route
                     Logo(Modifier.padding(start = 24.dp), visible = visible)
                     Spacer(modifier = Modifier.weight(1f))
-                    BallIcon(ballCount = 10, onClick = navigateToBall)
+                    BallIcon(ballCount = user?.ballCount ?: 0, onClick = navigateToBall)
                     NotificationIcon(onClick = navigateToNotification)
                 }
             )

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/main/MainViewModel.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/main/MainViewModel.kt
@@ -1,24 +1,37 @@
 package kr.co.knowledgerally.ui.main
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kr.co.knowledgerally.base.BaseViewModel
+import kr.co.knowledgerally.domain.usecase.GetUserStreamUseCase
 import kr.co.knowledgerally.domain.usecase.IsWelcomeShownUseCase
+import kr.co.knowledgerally.domain.usecase.RefreshUserUseCase
 import kr.co.knowledgerally.domain.usecase.ShownWelcomeUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+    getUserStreamUseCase: GetUserStreamUseCase,
+    private val refreshUserUseCase: RefreshUserUseCase,
     private val isWelcomeShownUseCase: IsWelcomeShownUseCase,
     private val shownWelcomeUseCase: ShownWelcomeUseCase,
 ) : BaseViewModel() {
-
     private val _showWelcome = MutableStateFlow(false)
     val showWelcome: StateFlow<Boolean> = _showWelcome.asStateFlow()
 
+    val user = getUserStreamUseCase()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
     init {
+        launch {
+            refreshUserUseCase().getOrThrow()
+        }
+
         launch {
             isWelcomeShownUseCase()
                 .onSuccess { _showWelcome.value = !it }

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,15 +40,21 @@ import kr.co.knowledgerally.ui.R
 import kr.co.knowledgerally.ui.component.ContainedBadge
 import kr.co.knowledgerally.ui.component.KnowllyContainedButton
 import kr.co.knowledgerally.ui.component.Loading
+import kr.co.knowledgerally.ui.mypage.dialog.LogoutDialog
+import kr.co.knowledgerally.ui.mypage.dialog.WithdrawalDialog
 import kr.co.knowledgerally.ui.splash.SplashActivity
 import kr.co.knowledgerally.ui.theme.KnowllyTheme
 
 @Composable
 fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel()) {
+    val context = LocalContext.current
+
     val state by viewModel.uiState.collectAsState()
     val loading by viewModel.loading.collectAsState()
     val isExpired by viewModel.isLoggedOut.collectAsState()
-    val context = LocalContext.current
+
+    var showLogoutDialog by remember { mutableStateOf(false) }
+    var showWithdrawalDialog by remember { mutableStateOf(false) }
 
     MyPageScreen(
         state = state,
@@ -53,9 +62,21 @@ fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel()) {
         onPushActiveChange = { viewModel.updatePushActive(it) },
         navigateToProfile = { },
         navigateToTermsOfService = { },
-        logout = { viewModel.logout() },
-        withdrawal = { viewModel.withdrawal() },
+        logout = { showLogoutDialog = true },
+        withdrawal = { showWithdrawalDialog = true },
     )
+
+    // Dialog
+    when {
+        showLogoutDialog -> LogoutDialog(
+            onDismiss = { showLogoutDialog = false },
+            onConfirm = { viewModel.logout() }
+        )
+        showWithdrawalDialog -> WithdrawalDialog(
+            onDismiss = { showWithdrawalDialog = false },
+            onConfirm = { viewModel.withdrawal() }
+        )
+    }
 
     LaunchedEffect(isExpired) {
         if (isExpired) {

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageScreen.kt
@@ -42,7 +42,7 @@ import kr.co.knowledgerally.ui.theme.KnowllyTheme
 
 @Composable
 fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel()) {
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.uiState.collectAsState()
     val loading by viewModel.loading.collectAsState()
     val isExpired by viewModel.isLoggedOut.collectAsState()
     val context = LocalContext.current
@@ -50,7 +50,7 @@ fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel()) {
     MyPageScreen(
         state = state,
         loading = loading,
-        onNotificationEnabledChange = { viewModel.updateNotificationEnabled(it) },
+        onPushActiveChange = { viewModel.updatePushActive(it) },
         navigateToProfile = { },
         navigateToTermsOfService = { },
         logout = { viewModel.logout() },
@@ -68,7 +68,7 @@ fun MyPageScreen(viewModel: MyPageViewModel = hiltViewModel()) {
 private fun MyPageScreen(
     state: MyPageUiState,
     loading: Boolean,
-    onNotificationEnabledChange: (Boolean) -> Unit,
+    onPushActiveChange: (Boolean) -> Unit,
     navigateToProfile: () -> Unit,
     navigateToTermsOfService: () -> Unit,
     logout: () -> Unit,
@@ -78,7 +78,7 @@ private fun MyPageScreen(
         when (state) {
             MyPageUiState.Loading -> MyPageScreen(
                 notificationEnabled = false,
-                onNotificationEnabledChange = { },
+                onPushActiveChange = { },
                 versionName = "",
                 userName = "",
                 isCoach = false,
@@ -88,11 +88,11 @@ private fun MyPageScreen(
                 withdrawal = { },
             )
             is MyPageUiState.Success -> MyPageScreen(
-                notificationEnabled = state.notificationEnabled,
-                onNotificationEnabledChange = onNotificationEnabledChange,
+                notificationEnabled = state.user.pushActive,
+                onPushActiveChange = onPushActiveChange,
                 versionName = state.versionName,
-                userName = state.userName,
-                isCoach = state.isCoach,
+                userName = state.user.profile.username,
+                isCoach = state.user.coach,
                 navigateToProfile = navigateToProfile,
                 navigateToTermsOfService = navigateToTermsOfService,
                 logout = logout,
@@ -109,7 +109,7 @@ private fun MyPageScreen(
 @Composable
 private fun MyPageScreen(
     notificationEnabled: Boolean,
-    onNotificationEnabledChange: (Boolean) -> Unit,
+    onPushActiveChange: (Boolean) -> Unit,
     versionName: String,
     userName: String,
     isCoach: Boolean,
@@ -135,7 +135,7 @@ private fun MyPageScreen(
             content = {
                 MyPageSwitch(
                     checked = notificationEnabled,
-                    onCheckedChange = onNotificationEnabledChange
+                    onCheckedChange = onPushActiveChange
                 )
             }
         )
@@ -295,7 +295,7 @@ private fun MyPageScreenPreview() {
         MyPageScreen(
             state = MyPageUiState.Loading,
             loading = false,
-            onNotificationEnabledChange = { },
+            onPushActiveChange = { },
             navigateToProfile = { },
             navigateToTermsOfService = { },
             logout = { },

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageUiState.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageUiState.kt
@@ -1,16 +1,12 @@
 package kr.co.knowledgerally.ui.mypage
 
+import kr.co.knowledgerally.domain.model.User
+
 sealed interface MyPageUiState {
     object Loading : MyPageUiState
 
-    /**
-     * TODO: User Model을 직접 받도록 개선
-     */
     data class Success(
-        val notificationEnabled: Boolean,
+        val user: User,
         val versionName: String,
-        val userName: String,
-        val isCoach: Boolean,
-        val remainingBallCount: Int,
     ) : MyPageUiState
 }

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageViewModel.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/MyPageViewModel.kt
@@ -13,6 +13,7 @@ import kr.co.knowledgerally.domain.model.VersionName
 import kr.co.knowledgerally.domain.usecase.GetUserStreamUseCase
 import kr.co.knowledgerally.domain.usecase.LogoutUseCase
 import kr.co.knowledgerally.domain.usecase.RefreshUserUseCase
+import kr.co.knowledgerally.domain.usecase.UpdatePushActiveUseCase
 import kr.co.knowledgerally.domain.usecase.WithdrawalUseCase
 import javax.inject.Inject
 
@@ -21,6 +22,7 @@ class MyPageViewModel @Inject constructor(
     versionName: VersionName,
     getUserStreamUseCase: GetUserStreamUseCase,
     private val refreshUserUseCase: RefreshUserUseCase,
+    private val updatePushActiveUseCase: UpdatePushActiveUseCase,
     private val withdrawalUseCase: WithdrawalUseCase,
     private val logoutUseCase: LogoutUseCase,
 ) : BaseViewModel() {
@@ -39,7 +41,7 @@ class MyPageViewModel @Inject constructor(
 
     fun updatePushActive(active: Boolean) {
         launch {
-            // TODO: Patch pushActive to active
+            updatePushActiveUseCase(active).getOrThrow()
             refreshUserUseCase().getOrThrow()
         }
     }

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/Dialog.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/Dialog.kt
@@ -1,0 +1,80 @@
+package kr.co.knowledgerally.ui.mypage.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.co.knowledgerally.ui.component.KnowllyContainedButton
+import kr.co.knowledgerally.ui.component.KnowllyOutlinedButton
+import kr.co.knowledgerally.ui.theme.KnowllyTheme
+
+@Composable
+fun DialogContent(
+    text: String,
+    dismiss: String,
+    onDismiss: () -> Unit,
+    confirm: String,
+    onConfirm: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp)
+        ) {
+            Text(
+                text = text,
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .align(Alignment.CenterHorizontally),
+                style = KnowllyTheme.typography.subtitle3,
+            )
+
+            Row(
+                modifier = Modifier
+                    .padding(top = 28.dp)
+                    .fillMaxWidth(),
+            ) {
+                KnowllyOutlinedButton(
+                    text = dismiss,
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(40.dp)
+                )
+                KnowllyContainedButton(
+                    text = confirm,
+                    onClick = onConfirm,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 12.dp)
+                        .height(40.dp)
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 312)
+@Composable
+private fun DialogContentPreview() {
+    KnowllyTheme {
+        DialogContent(
+            text = "로그아웃 하시겠습니까?",
+            dismiss = "취소",
+            onDismiss = { },
+            confirm = "로그아웃",
+            onConfirm = { }
+        )
+    }
+}

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/LogoutDialog.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/LogoutDialog.kt
@@ -1,0 +1,28 @@
+package kr.co.knowledgerally.ui.mypage.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kr.co.knowledgerally.ui.R
+import kr.co.knowledgerally.ui.theme.KnowllyTheme
+
+@Composable
+fun LogoutDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = { },
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
+    ) {
+        DialogContent(
+            text = stringResource(id = R.string.dialog_logout_text),
+            dismiss = stringResource(R.string.dialog_logout_dismiss),
+            onDismiss = onDismiss,
+            confirm = stringResource(R.string.dialog_logout_confirm),
+            onConfirm = onConfirm
+        )
+    }
+}

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/WithdrawalDialog.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/mypage/dialog/WithdrawalDialog.kt
@@ -1,0 +1,26 @@
+package kr.co.knowledgerally.ui.mypage.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kr.co.knowledgerally.ui.R
+
+@Composable
+fun WithdrawalDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = { },
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
+    ) {
+        DialogContent(
+            text = stringResource(id = R.string.dialog_withdrawal_text),
+            dismiss = stringResource(R.string.dialog_withdrawal_dismiss),
+            onDismiss = onDismiss,
+            confirm = stringResource(R.string.dialog_withdrawal_confirm),
+            onConfirm = onConfirm
+        )
+    }
+}

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpActivity.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpActivity.kt
@@ -25,11 +25,10 @@ class SignUpActivity : BaseActivity() {
         setContent {
             KnowllyTheme {
                 SignUpScreen(
-                    viewModel = viewModel,
                     navigateUp = ::navigateUp,
                     navigateToTerms = ::startTermsActivity,
                     navigateToPolicy = ::startPolicyActivity,
-                    signUp = { viewModel.signUp() }
+                    signUp = { pushActive -> viewModel.signUp(pushActive) }
                 )
             }
         }

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpScreen.kt
@@ -24,17 +24,15 @@ import kr.co.knowledgerally.ui.theme.KnowllyTheme
 
 /**
  * TODO
- * 1. 가입하기 클릭 이벤트
- * 2. 뒤로가기 클릭 이벤트
+ * 1. 뒤로가기 클릭 이벤트
  */
 
 @Composable
 fun SignUpScreen(
-    viewModel: SignUpViewModel,
     navigateUp: () -> Unit,
     navigateToTerms: () -> Unit,
     navigateToPolicy: () -> Unit,
-    signUp: () -> Unit
+    signUp: (Boolean) -> Unit
 ) {
     val signUpState = rememberSignUpState()
     SignUpScreen(
@@ -42,7 +40,7 @@ fun SignUpScreen(
         navigateUp = navigateUp,
         navigateToTerms = navigateToTerms,
         navigateToPolicy = navigateToPolicy,
-        signUp = signUp
+        signUp = { signUp(signUpState.notificationState.isChecked) }
     )
 }
 
@@ -180,7 +178,7 @@ fun SignUpButton(
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun SignUpScreenPreview() {
     KnowllyTheme {

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpViewModel.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/signup/SignUpViewModel.kt
@@ -25,14 +25,13 @@ class SignUpViewModel @Inject constructor(
 
     private var job: Job? = null
 
-    // TODO: 알림 수신동의 필드 받기
-    fun signUp() {
+    fun signUp(pushActive: Boolean) {
         if (job?.isActive == true) {
             return
         }
         job = launch {
             val providerToken = ProviderToken.kakao(providerAccessToken)
-            signUpUseCase(providerToken)
+            signUpUseCase(providerToken, pushActive)
                 .onSuccess { _result.value = SignUpResult.Success }
                 .onFailure { handleException(it) }
         }

--- a/modules/presentation/src/main/res/values/strings.xml
+++ b/modules/presentation/src/main/res/values/strings.xml
@@ -148,4 +148,13 @@
     <string name="schedule_title">클래스 일정 추가하기</string>
     <string name="schedule_subtitle">날짜 선택</string>
     <string name="schedule_description">편하신 날짜를 하나 선택해주세요.</string>
+
+    <string name="dialog_logout_text">로그아웃 하시겠습니까?</string>
+    <string name="dialog_logout_dismiss">취소</string>
+    <string name="dialog_logout_confirm">로그아웃</string>
+
+    <string name="dialog_withdrawal_text">정말 탈퇴 하시겠어요?</string>
+    <string name="dialog_withdrawal_dismiss">취소</string>
+    <string name="dialog_withdrawal_confirm">탈퇴하기</string>
+
 </resources>

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/api/ApiService.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/api/ApiService.kt
@@ -1,15 +1,18 @@
 package kr.co.knowledgerally.remote.api
 
-import kr.co.knowledgerally.remote.model.UserResponseWrapper
 import kr.co.knowledgerally.remote.model.OnboardRequest
 import kr.co.knowledgerally.remote.model.OnboardedResponse
 import kr.co.knowledgerally.remote.model.ProviderTokenRequest
 import kr.co.knowledgerally.remote.model.SignUpResponse
+import kr.co.knowledgerally.remote.model.UserResponseWrapper
 import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 
@@ -35,4 +38,8 @@ internal interface ApiService {
 
     @POST("user/onboard")
     suspend fun submitOnboard(@Body onboard: OnboardRequest)
+
+    @FormUrlEncoded
+    @PATCH("user/setting/push")
+    suspend fun updatePushActive(@Field("pushActive") active: Boolean)
 }

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/api/ApiService.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/api/ApiService.kt
@@ -1,5 +1,6 @@
 package kr.co.knowledgerally.remote.api
 
+import kr.co.knowledgerally.remote.model.UserResponseWrapper
 import kr.co.knowledgerally.remote.model.OnboardRequest
 import kr.co.knowledgerally.remote.model.OnboardedResponse
 import kr.co.knowledgerally.remote.model.ProviderTokenRequest
@@ -21,6 +22,9 @@ internal interface ApiService {
 
     @DELETE("user/me")
     suspend fun withdrawal()
+
+    @GET("user/me")
+    suspend fun getUser(): UserResponseWrapper
 
     @GET("user/user-onboarded") // 임시 endpoint, 확정 후 수정 필요
     suspend fun isOnboarded(): OnboardedResponse

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserImageResponse.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserImageResponse.kt
@@ -1,0 +1,8 @@
+package kr.co.knowledgerally.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class UserImageResponse(
+    @SerializedName("userImgUrl")
+    val userImageUrl: String?,
+)

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponse.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponse.kt
@@ -1,15 +1,24 @@
 package kr.co.knowledgerally.remote.model
 
+import com.google.gson.annotations.SerializedName
 import kr.co.knowledgerally.data.model.ProfileEntity
 import kr.co.knowledgerally.data.model.UserEntity
 
 data class UserResponse(
+    @SerializedName("id")
     val id: String,
+    @SerializedName("username")
     val username: String,
+    @SerializedName("intro")
     val introduction: String,
+    @SerializedName("portfolio")
     val portfolio: String?,
+    @SerializedName("ballCnt")
     val ballCount: Int,
+    @SerializedName("pushActive")
     val pushActive: Boolean,
+    @SerializedName("coach")
+    val coach: Boolean,
 )
 
 fun UserResponse.toData(imageUrl: String?) = UserEntity(
@@ -21,5 +30,6 @@ fun UserResponse.toData(imageUrl: String?) = UserEntity(
         imageUrl = imageUrl
     ),
     ballCount = ballCount,
-    pushActive = pushActive
+    pushActive = pushActive,
+    coach = coach,
 )

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponse.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponse.kt
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.remote.model
+
+import kr.co.knowledgerally.data.model.ProfileEntity
+import kr.co.knowledgerally.data.model.UserEntity
+
+data class UserResponse(
+    val id: String,
+    val username: String,
+    val introduction: String,
+    val portfolio: String?,
+    val ballCount: Int,
+    val pushActive: Boolean,
+)
+
+fun UserResponse.toData(imageUrl: String?) = UserEntity(
+    id = id,
+    profile = ProfileEntity(
+        username = username,
+        introduction = introduction,
+        portfolio = portfolio ?: "",
+        imageUrl = imageUrl
+    ),
+    ballCount = ballCount,
+    pushActive = pushActive
+)

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponseWrapper.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponseWrapper.kt
@@ -11,6 +11,6 @@ data class UserResponseWrapper(
         @SerializedName("user")
         val user: UserResponse,
         @SerializedName("userImage")
-        val userImageResponse: UserImageResponse,
+        val userImage: UserImageResponse,
     )
 }

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponseWrapper.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/model/UserResponseWrapper.kt
@@ -1,0 +1,16 @@
+package kr.co.knowledgerally.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class UserResponseWrapper(
+    @SerializedName("data")
+    val data: Data,
+) {
+
+    data class Data(
+        @SerializedName("user")
+        val user: UserResponse,
+        @SerializedName("userImage")
+        val userImageResponse: UserImageResponse,
+    )
+}

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
@@ -42,4 +42,8 @@ internal class UserRemoteDataSourceImpl @Inject constructor(
         val imageUrl = data.userImageResponse.userImageUrl
         data.user.toData(imageUrl)
     }
+
+    override suspend fun updatePushActive(active: Boolean): Result<Unit> = runCatching {
+        apiService.updatePushActive(active)
+    }
 }

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
@@ -3,9 +3,11 @@ package kr.co.knowledgerally.remote.source
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kr.co.knowledgerally.data.model.OnboardEntity
+import kr.co.knowledgerally.data.model.UserEntity
 import kr.co.knowledgerally.data.source.UserRemoteDataSource
 import kr.co.knowledgerally.remote.api.ApiService
 import kr.co.knowledgerally.remote.image.ImageTranscoder
+import kr.co.knowledgerally.remote.model.toData
 import kr.co.knowledgerally.remote.model.toRemote
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -33,5 +35,11 @@ internal class UserRemoteDataSourceImpl @Inject constructor(
             apiService.uploadUserImage(image)
         }
         apiService.submitOnboard(onboard.toRemote())
+    }
+
+    override suspend fun getUser(): Result<UserEntity> = runCatching {
+        val data = apiService.getUser().data
+        val imageUrl = data.userImageResponse.userImageUrl
+        data.user.toData(imageUrl)
     }
 }

--- a/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
+++ b/modules/remote/src/main/java/kr/co/knowledgerally/remote/source/UserRemoteDataSourceImpl.kt
@@ -39,7 +39,7 @@ internal class UserRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun getUser(): Result<UserEntity> = runCatching {
         val data = apiService.getUser().data
-        val imageUrl = data.userImageResponse.userImageUrl
+        val imageUrl = data.userImage.userImageUrl
         data.user.toData(imageUrl)
     }
 


### PR DESCRIPTION
- 유저 정보를 가져오거나 새로고침 하는 기능 추가
- 가입, 알림 수신동의 변경시 `setting/push` API 호출
- 마이페이지 다이얼로그 추가
- 마이페이지 User 정보를 바라보도록 함