### PR TITLE
가입 요청 API 호출 로직 개선

### DIFF
--- a/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/SignUpUseCase.kt
+++ b/modules/domain/src/main/java/kr/co/knowledgerally/domain/usecase/SignUpUseCase.kt
@@ -15,5 +15,9 @@ class SignUpUseCase @Inject constructor(
         pushActive: Boolean
     ): Result<Unit> = authRepository
         .signUp(providerToken)
-        .mapCatching { userRepository.updatePushActive(pushActive).getOrThrow() }
+        .mapCatching {
+            if (pushActive) {
+                userRepository.updatePushActive(pushActive).getOrThrow()
+            }
+        }
 }


### PR DESCRIPTION
## 개요
- 가입시 항상 `setting/push` 요청을 보내고 있는데 `true`일 경우에만 호출하도록 개선