### PR TITLE
로그인 오류 실패 로직 개선

### DIFF
--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/component/Loading.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/component/Loading.kt
@@ -1,16 +1,28 @@
 package kr.co.knowledgerally.ui.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
 fun Loading(modifier: Modifier = Modifier) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .clickable(
+                enabled = true,
+                onClickLabel = null,
+                onClick = { },
+                role = null,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
         contentAlignment = Alignment.Center
     ) {
         CircularProgressIndicator()

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/login/LoginActivity.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/login/LoginActivity.kt
@@ -5,6 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -14,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kr.co.knowledgerally.base.BaseActivity
 import kr.co.knowledgerally.feature.kakao.KakaoLogin
+import kr.co.knowledgerally.ui.component.Loading
 import kr.co.knowledgerally.ui.main.MainActivity
 import kr.co.knowledgerally.ui.policy.PolicyActivity
 import kr.co.knowledgerally.ui.profile.ProfileActivity
@@ -48,12 +54,19 @@ class LoginActivity : BaseActivity() {
         val systemUiController: SystemUiController = rememberSystemUiController()
         systemUiController.setStatusBarColor(KnowllyTheme.colors.primaryLight)
 
+        val loading by viewModel.loading.collectAsState()
+
         KnowllyTheme {
-            LoginScreen(
-                onLogin = { requestKakaoLogin() },
-                navigateToTerms = { startTermsActivity() },
-                navigateToPolicy = { startPolicyActivity() }
-            )
+            Box(modifier = Modifier.fillMaxSize()) {
+                LoginScreen(
+                    onLogin = { requestKakaoLogin() },
+                    navigateToTerms = { startTermsActivity() },
+                    navigateToPolicy = { startPolicyActivity() }
+                )
+                if (loading) {
+                    Loading()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- Activity의 코루틴에서 실행해서 오류가 전파되지 않고 크래시 발생
- 로딩 뷰가 있는 경우 터치가 불가능 하도록 함