### PR TITLE
운영 및 수강 클래스 UI 수정사항 반영

### DIFF
--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/coach/MatchingTabContent.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/coach/MatchingTabContent.kt
@@ -75,7 +75,6 @@ private fun MatchingItem(
             onClick = { navigateToApplicant(item.lectureInfo.id) },
             modifier = Modifier.padding(top = 8.dp)
         )
-        VerticalSpacer(height = 16.dp)
         CoachDivider()
     }
 }
@@ -108,7 +107,7 @@ private fun MatchingItemApplicant(
     Row(
         modifier = modifier
             .clickable { onClick() }
-            .padding(start = 14.dp),
+            .padding(bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -118,6 +117,7 @@ private fun MatchingItemApplicant(
             ),
             style = KnowllyTheme.typography.body2,
             color = KnowllyTheme.colors.primaryDark,
+            modifier = Modifier.padding(start = 14.dp)
         )
         Icon(
             painter = painterResource(id = R.drawable.ic_chevron_right),

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/player/PlayerContent.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/player/PlayerContent.kt
@@ -66,7 +66,7 @@ private fun Matching(
         LazyColumn {
             itemsIndexed(
                 items = items,
-                key = { _, item -> item }
+                key = { _, item -> item.lecture.id }
             ) { index, item ->
                 MatchingItem(item = item, navigateToLecture = navigateToLecture)
 
@@ -89,7 +89,7 @@ private fun Scheduled(
         LazyColumn {
             itemsIndexed(
                 items = items,
-                key = { _, item -> item }
+                key = { _, item -> item.lecture.id }
             ) { index, item ->
                 ScheduleItem(item = item, navigateToLecture = navigateToLecture)
 
@@ -113,7 +113,7 @@ private fun Completed(
         LazyColumn {
             itemsIndexed(
                 items = items,
-                key = { _, item -> item }
+                key = { _, item -> item.lecture.id }
             ) { index, item ->
                 CompletedItem(
                     item = item,

--- a/modules/presentation/src/main/res/values/strings.xml
+++ b/modules/presentation/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="player_not_reviewed">후기 미작성</string>
 
     <string name="lecture_date_format">yyyy년 M월 d일 (E)</string>
-    <string name="lecture_time_format">a H:mm</string>
+    <string name="lecture_time_format">a h:mm</string>
     <string name="lecture_runningtime_format">(%d시간 수업)</string>
 
     <string name="applicant_title">매칭 신청인</string>
@@ -169,7 +169,7 @@
     <string name="register_schedule_description">편한 일정을 등록해주세요.7개까지 등록할 수 있어요. \n가능한 일정이 많을수록 매칭률이 올라가요!</string>
     <string name="register_schedule_add_schedule">일정 추가</string>
     <string name="register_schedule_date_fmt">M월 d일 (E)</string>
-    <string name="register_schedule_time_fmt">a H:mm</string>
+    <string name="register_schedule_time_fmt">a h:mm</string>
     <string name="register_schedule_already_contains_schedule">이미 추가된 일정입니다.</string>
     <string name="register_schedule_complete">클래스 등록이 완료되었습니다.</string>
 


### PR DESCRIPTION
## 이슈
- resolved: #230

## 내용
- `LazyColumn`의 item 키 값 런타임 오류 수정
- 클래스 시간을 24h이 아닌 12h로 표시하도록 수정
- 운영클래스 매칭신청인 버튼 터치 영역 디자이너 피드백 반영 (사진 참조)

![asdf](https://user-images.githubusercontent.com/72238126/178461209-7acdc9e2-a442-4eb9-9656-a93e5b7eb7cc.gif)

