### PR TITLE
로딩 UI 및 버튼 토스트 수정

### DIFF
--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/ball/BallScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/ball/BallScreen.kt
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.ui.ball
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
@@ -158,7 +160,9 @@ fun BallHistoryContent(uiState: BallUiState) {
         is BallUiState.Success -> {
             BallHistoryList(histories = uiState.histories)
         }
-        BallUiState.Loading -> {}
+        BallUiState.Loading -> {
+            BallLoading()
+        }
         BallUiState.Failure -> {}
     }
 }
@@ -205,6 +209,13 @@ fun BallHistoryListItem(
     }
 }
 
+@Composable
+fun BallLoading() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun BallScreenPreview() {
@@ -231,7 +242,7 @@ private fun BallScreenPreview() {
 
     KnowllyTheme {
         BallScreen(
-            uiState = BallUiState.Success(10, tempBallHistoryList),
+            uiState = BallUiState.Loading,
             navigateUp = {},
             navigateToGuide = {}
         )

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/ball/BallScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/ball/BallScreen.kt
@@ -3,7 +3,6 @@ package kr.co.knowledgerally.ui.ball
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
@@ -36,6 +34,7 @@ import kr.co.knowledgerally.domain.model.BallHistory
 import kr.co.knowledgerally.ui.R
 import kr.co.knowledgerally.ui.component.HorizontalSpacer
 import kr.co.knowledgerally.ui.component.KnowllyTopAppBar
+import kr.co.knowledgerally.ui.component.Loading
 import kr.co.knowledgerally.ui.component.VerticalSpacer
 import kr.co.knowledgerally.ui.theme.KnowllyTheme
 import java.time.LocalDate
@@ -161,7 +160,7 @@ fun BallHistoryContent(uiState: BallUiState) {
             BallHistoryList(histories = uiState.histories)
         }
         BallUiState.Loading -> {
-            BallLoading()
+            Loading()
         }
         BallUiState.Failure -> {}
     }
@@ -206,13 +205,6 @@ fun BallHistoryListItem(
             text = "$sign ${abs(history.count)}" + stringResource(id = R.string.ball_count),
             style = KnowllyTheme.typography.subtitle1
         )
-    }
-}
-
-@Composable
-fun BallLoading() {
-    Box(modifier = Modifier.fillMaxSize()) {
-        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
     }
 }
 

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/notification/NotificationScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/notification/NotificationScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -202,7 +203,9 @@ fun NotificationContent(
 
 @Composable
 fun LoadingNotification() {
-    CircularProgressIndicator()
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    }
 }
 
 @Composable
@@ -266,6 +269,18 @@ private fun NotificationScreenPreviewEmpty() {
     KnowllyTheme {
         NotificationScreen(
             state = NotificationUiState.Empty,
+            navigateUp = {},
+            onNotificationClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NotificationScreenPreviewLoading() {
+    KnowllyTheme {
+        NotificationScreen(
+            state = NotificationUiState.Loading,
             navigateUp = {},
             onNotificationClick = {}
         )

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/notification/NotificationScreen.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/notification/NotificationScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -30,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import kr.co.knowledgerally.ui.R
 import kr.co.knowledgerally.ui.component.HorizontalSpacer
 import kr.co.knowledgerally.ui.component.KnowllyTopAppBar
+import kr.co.knowledgerally.ui.component.Loading
 import kr.co.knowledgerally.ui.component.VerticalSpacer
 import kr.co.knowledgerally.ui.model.NotificationModel
 import kr.co.knowledgerally.ui.theme.KnowllyTheme
@@ -84,7 +83,7 @@ fun NotificationContent(
             onNotificationClick = onNotificationClick
         )
         NotificationUiState.Loading -> {
-            LoadingNotification()
+            Loading()
         }
         NotificationUiState.Empty -> {
             EmptyNotification(modifier = Modifier.fillMaxSize())
@@ -199,13 +198,6 @@ fun NotificationContent(
         style = KnowllyTheme.typography.body1,
         color = KnowllyTheme.colors.gray44
     )
-}
-
-@Composable
-fun LoadingNotification() {
-    Box(modifier = Modifier.fillMaxSize()) {
-        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-    }
 }
 
 @Composable

--- a/modules/presentation/src/main/java/kr/co/knowledgerally/ui/player/KakaoIdCopyButton.kt
+++ b/modules/presentation/src/main/java/kr/co/knowledgerally/ui/player/KakaoIdCopyButton.kt
@@ -1,12 +1,11 @@
 package kr.co.knowledgerally.ui.player
 
-import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import kr.co.knowledgerally.toast.Toaster
 import kr.co.knowledgerally.ui.R
 import kr.co.knowledgerally.ui.component.KnowllyOutlinedButton
 
@@ -15,15 +14,13 @@ fun KakaoIdCopyButton(
     kakaoId: String,
     modifier: Modifier = Modifier
 ) {
-    val context = LocalContext.current
-    val toastMessage = stringResource(id = R.string.copied_kakao_id)
     val clipboardManager = LocalClipboardManager.current
 
     KnowllyOutlinedButton(
         text = stringResource(id = R.string.copy_kakao_id),
         onClick = {
             clipboardManager.setText(AnnotatedString(kakaoId))
-            Toast.makeText(context, toastMessage, Toast.LENGTH_LONG).show()
+            Toaster.show(R.string.copied_kakao_id)
         },
         modifier = modifier
     )


### PR DESCRIPTION
## 이슈
- resolved: #236

## 내용
- 알림 화면 로딩 UI가 중앙에 오지 않는 이슈 수정
- 볼 내역 로딩 UI가 누락되어 있는 이슈 수정
- 수강 클래스의 카카오 ID 복사 버튼이 구형 토스트를 사용하는 이슈 수정